### PR TITLE
Added: Display propery memory usage (don't add application cache memory)

### DIFF
--- a/custom_components/docker_monitor/helpers.py
+++ b/custom_components/docker_monitor/helpers.py
@@ -335,7 +335,7 @@ class DockerContainerStats(threading.Thread):
         # Memory stats
         memory = {}
         try:
-            memory['usage'] = raw['memory_stats']['usage']
+            memory['usage'] = raw['memory_stats']['usage'] - raw['memory_stats']['stats']['cache']
             memory['limit'] = raw['memory_stats']['limit']
             memory['max_usage'] = raw['memory_stats']['max_usage']
         except (KeyError, TypeError) as e:


### PR DESCRIPTION
Current implementation displays the wrong memory usage, because it includes the file-system cache too. This fix subtract this properly ;-)